### PR TITLE
:bug: exclude latest version of sphinx-new-tab-link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'myst_nb',
     'sphinx.ext.napoleon',
-    # 'sphinx_new_tab_link',  # create infinite loop error
+    'sphinx_new_tab_link',
 ]
 
 #  https://myst-nb.readthedocs.io/en/latest/computation/execute.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ docs =
     sphinx-book-theme
     myst-nb
     ipywidgets
-    sphinx-new-tab-link
+    sphinx-new-tab-link!=0.2.2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
see https://github.com/ftnext/sphinx-new-tab-link/issues/11

- recurssion error introduced into 0.2.2 of sphinx-new-tab-link