### PR TITLE
Action colab tutorial

### DIFF
--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -1,0 +1,24 @@
+name: Test that tutorial runs on latest colab image
+
+on:
+  push:
+  schedule:
+    - cron: '0 2 * * 3'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    # https://console.cloud.google.com/artifacts/docker/colab-images/europe/public/runtime
+    container:
+      image: europe-docker.pkg.dev/colab-images/public/runtime:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test tutorials
+        run: | 
+          python3 -m pip install papermill ipykernel njab
+          cd docs/tutorial
+          papermill explorative_analysis.ipynb --help-notebook
+          papermill log_reg.ipynb --help-notebook
+          papermill explorative_analysis.ipynb explorative_analysis_tested.ipynb
+          papermill log_reg.ipynb log_reg_tested.ipynb

--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -21,4 +21,5 @@ jobs:
           papermill explorative_analysis.ipynb --help-notebook
           papermill log_reg.ipynb --help-notebook
           papermill explorative_analysis.ipynb explorative_analysis_tested.ipynb
+          pip install njab heatmapz openpyxl "matplotlib<3.7" plotly
           papermill log_reg.ipynb log_reg_tested.ipynb

--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4core # increase disk space  
     # https://console.cloud.google.com/artifacts/docker/colab-images/europe/public/runtime
     container:
       image: europe-docker.pkg.dev/colab-images/public/runtime:latest


### PR DESCRIPTION
Start testing tutorials on colab using [docker image of google colab](https://console.cloud.google.com/artifacts/docker/colab-images/europe/public/runtime).

Needs a [larger runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#larger-runners) due to disk-space requirements.

Aim: Check weekly that tutorial runs on latest colab deployment.