### PR TITLE
:bug: make all imports explicit

### DIFF
--- a/src/njab/__init__.py
+++ b/src/njab/__init__.py
@@ -6,7 +6,7 @@ logistic regression as a simple and explainable model.
 """
 from importlib.metadata import version
 
-from . import stats, sklearn, plotting, pandas, io
+from njab import stats, sklearn, plotting, pandas, io
 
 __version__ = version('njab')
 

--- a/src/njab/__init__.py
+++ b/src/njab/__init__.py
@@ -6,7 +6,7 @@ logistic regression as a simple and explainable model.
 """
 from importlib.metadata import version
 
-from njab import stats, sklearn, plotting, pandas, io
+from njab import io, pandas, plotting, sklearn, stats
 
 __version__ = version('njab')
 

--- a/src/njab/sklearn/__init__.py
+++ b/src/njab/sklearn/__init__.py
@@ -8,13 +8,13 @@ from typing import Optional
 import pandas as pd
 import sklearn
 import sklearn.model_selection
-
 from mrmr import mrmr_classif
 
-from .types import Splits, ResultsSplit, Results, AucRocCurve, PrecisionRecallCurve
-from .pca import run_pca
-from .preprocessing import StandardScaler
-from . import scoring
+from njab.sklearn import scoring
+from njab.sklearn.pca import run_pca
+from njab.sklearn.preprocessing import StandardScaler
+from njab.sklearn.types import (AucRocCurve, PrecisionRecallCurve, Results,
+                                ResultsSplit, Splits)
 
 __all__ = [
     'run_model',

--- a/src/njab/sklearn/__init__.py
+++ b/src/njab/sklearn/__init__.py
@@ -8,7 +8,6 @@ from typing import Optional
 import pandas as pd
 import sklearn
 import sklearn.model_selection
-from mrmr import mrmr_classif
 
 from njab.sklearn import scoring
 from njab.sklearn.pca import run_pca
@@ -42,6 +41,7 @@ def run_model(
     """Fit a model on the training split and calculate
        performance metrics on both train and test split.
     """
+    from mrmr import mrmr_classif
     selected_features = mrmr_classif(X=splits.X_train,
                                      y=splits.y_train,
                                      K=n_feat_to_select)
@@ -102,6 +102,7 @@ def find_n_best_features(
         return_train_score: bool = False,
         fit_params: Optional[dict] = None):
     """Create a summary of model performance on 10 times 5-fold cross-validation."""
+    from mrmr import mrmr_classif
     summary = []
     cv = sklearn.model_selection.RepeatedStratifiedKFold(
         n_splits=5, n_repeats=10, random_state=random_state)

--- a/src/njab/sklearn/scoring.py
+++ b/src/njab/sklearn/scoring.py
@@ -1,8 +1,8 @@
+import numpy as np
 import pandas as pd
 import sklearn.metrics as sklm
-import numpy as np
 
-from .types import Results
+from njab.sklearn.types import Results
 
 
 class ConfusionMatrix():

--- a/src/njab/stats/__init__.py
+++ b/src/njab/stats/__init__.py
@@ -4,7 +4,7 @@ Analysis of covariance, binomial testing for binary variables,
 and differential analysis of continuous variables between groups
 using t-tests.
 """
-from . import ancova
-from .groups_comparision import diff_analysis, binomtest
+from njab.stats import ancova
+from njab.stats.groups_comparision import binomtest, diff_analysis
 
 __all__ = ['ancova', 'diff_analysis', 'binomtest']


### PR DESCRIPTION
The issue for M1 Macs is polars, which needs to use the arm instructions. Apparently M1 Macs can use two versions of instructions, but the details are a bit misterious. Anyways

In `mrmr-selection` the line 

```bash
import polars
```

leads to `zsh: i

see [here](https://github.com/pola-rs/polars/issues/11650)

The current workaround for upstream packages using njab (like pimms-learn) is to only import mrmr-selection once it is needed...